### PR TITLE
update uv install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 Then use UV to install toad:
 
 ```bash
-uv tool install -U batrachian-toad
+uv tool install -U batrachian-toad --python 3.14
 ```
 
 ## Using Toad


### PR DESCRIPTION
The original command didn't work for me, even though my Python version is relatively new (Python 3.12.8)

I think uv command should include python 3.14 if you really depend on that version