### PR TITLE
Add bindings for alt+delete/backspace

### DIFF
--- a/src/toad/widgets/prompt.py
+++ b/src/toad/widgets/prompt.py
@@ -96,6 +96,20 @@ class PromptTextArea(HighlightedTextArea):
             priority=True,
             show=False,
         ),
+        Binding(
+            "alt+backspace",
+            "delete_word_left",
+            "Delete word left",
+            tooltip="Delete the word to the left of cursor",
+            show=False,
+        ),
+        Binding(
+            "alt+delete",
+            "delete_word_right",
+            "Delete word right",
+            tooltip="Delete the word to the right of cursor",
+            show=False,
+        ),
     ]
 
     app = getters.app(ToadApp)


### PR DESCRIPTION
Added Alt/Option+Delete and Alt/Option+Backspace keyboard shortcuts for word-by-word deletion in the prompt input field, matching standard macOS text field behavior.