### PR TITLE
fix: add missing theme variants to settings menu

### DIFF
--- a/src/toad/settings_schema.py
+++ b/src/toad/settings_schema.py
@@ -1,6 +1,5 @@
 from toad.settings import SchemaDict
 
-
 SCHEMA: list[SchemaDict] = [
     {
         "key": "ui",
@@ -23,9 +22,13 @@ SCHEMA: list[SchemaDict] = [
                     "monokai",
                     "nord",
                     "solarized-light",
+                    "solarized-dark",
                     "textual-dark",
                     "textual-light",
                     "tokyo-night",
+                    "rose-pine",
+                    "rose-pine-moon",
+                    "rose-pine-dawn",
                 ],
             },
             {


### PR DESCRIPTION
[Relevant Discussion Post](https://github.com/batrachianai/toad/discussions/107)

This pull request tries to correct the mismatch between themes available between the command palette choices and the settings menu choices.  It looks like the rose-pine variants are the only ones missing from the settings menu. 