### PR TITLE
feat: add support for custom agents from config directory

### DIFF
--- a/src/toad/agents.py
+++ b/src/toad/agents.py
@@ -1,7 +1,9 @@
+from dataclasses import dataclass, field
 from importlib.resources import files
 import asyncio
+from pathlib import Path
 
-from toad.agent_schema import Agent
+from toad.agent_schema import Agent, ValidationError, validate_agent
 from toad.paths import get_config
 
 
@@ -9,24 +11,52 @@ class AgentReadError(Exception):
     """Problem reading the agents."""
 
 
-async def read_agents() -> dict[str, Agent]:
+@dataclass
+class AgentValidationError:
+    """Represents a validation error for a custom agent."""
+
+    file_path: Path
+    error_message: str
+
+
+@dataclass
+class AgentReadResult:
+    """Result of reading agents, including any validation errors."""
+
+    agents: dict[str, Agent] = field(default_factory=dict)
+    validation_errors: list[AgentValidationError] = field(default_factory=list)
+
+
+async def read_agents() -> AgentReadResult:
     """Read agent information from data/agents and <toad_config_path>/agents/
 
     Raises:
-        AgentReadError: If the files could not be read.
+        AgentReadError: If the built-in agents could not be read.
 
     Returns:
-        A mapping of identity on to Agent dict.
+        AgentReadResult containing valid agents and any validation errors from custom agents.
     """
     import tomllib
 
-    def load_agent(file) -> Agent | None:
-        """Load an agent from a TOML file, returning None if inactive."""
-        with file.open("rb") as f:
-            agent: Agent = tomllib.load(f)
-            return agent if agent.get("active", True) else None
+    def load_agent(file, validate: bool = False) -> Agent | None:
+        """Load an agent from a TOML file, returning None if inactive.
 
-    def read_agents() -> dict[str, Agent]:
+        Args:
+            file: The file to load.
+            validate: If True, validate against the Agent schema.
+
+        Raises:
+            ValidationError: If validation is enabled and fails.
+        """
+        with file.open("rb") as f:
+            agent = tomllib.load(f)
+            if not agent.get("active", True):
+                return None
+            if validate:
+                return validate_agent(agent, file)
+            return agent  # type: ignore[return-value]
+
+    def read_agents() -> AgentReadResult:
         """Read agent information.
 
         Loads built-in agents from data/agents, then custom agents from
@@ -34,28 +64,43 @@ async def read_agents() -> dict[str, Agent]:
         will override built-in ones.
 
         Returns:
-            Mapping of identity to agent dicts.
+            AgentReadResult with valid agents and validation errors.
         """
-        agents: dict[str, Agent] = {}
+        result = AgentReadResult()
 
         def add_agent(agent: Agent) -> None:
             identity = agent.get("identity")
             if identity:
-                agents[identity] = agent
+                result.agents[identity] = agent
 
         try:
             for file in files("toad.data").joinpath("agents").iterdir():
                 if agent := load_agent(file):
                     add_agent(agent)
-
-            custom_agents_dir = get_config() / "agents"
-            if custom_agents_dir.exists():
-                for file in custom_agents_dir.glob("*.toml"):
-                    if agent := load_agent(file):
-                        add_agent(agent)
         except Exception as error:
-            raise AgentReadError(f"Failed to read agents; {error}")
+            raise AgentReadError(f"Failed to read built-in agents; {error}")
 
-        return agents
+        custom_agents_dir = get_config() / "agents"
+        if custom_agents_dir.exists():
+            for file in custom_agents_dir.glob("*.toml"):
+                try:
+                    if agent := load_agent(file, validate=True):
+                        add_agent(agent)
+                except ValidationError as error:
+                    result.validation_errors.append(
+                        AgentValidationError(
+                            file_path=file,
+                            error_message=str(error),
+                        )
+                    )
+                except Exception as error:
+                    result.validation_errors.append(
+                        AgentValidationError(
+                            file_path=file,
+                            error_message=f"Failed to load agent: {error}",
+                        )
+                    )
+
+        return result
 
     return await asyncio.to_thread(read_agents)

--- a/src/toad/agents.py
+++ b/src/toad/agents.py
@@ -2,6 +2,7 @@ from importlib.resources import files
 import asyncio
 
 from toad.agent_schema import Agent
+from toad.paths import get_config
 
 
 class AgentReadError(Exception):
@@ -9,7 +10,7 @@ class AgentReadError(Exception):
 
 
 async def read_agents() -> dict[str, Agent]:
-    """Read agent information from data/agents
+    """Read agent information from data/agents and <toad_config_path>/agents/
 
     Raises:
         AgentReadError: If the files could not be read.
@@ -19,27 +20,42 @@ async def read_agents() -> dict[str, Agent]:
     """
     import tomllib
 
-    def read_agents() -> list[Agent]:
+    def load_agent(file) -> Agent | None:
+        """Load an agent from a TOML file, returning None if inactive."""
+        with file.open("rb") as f:
+            agent: Agent = tomllib.load(f)
+            return agent if agent.get("active", True) else None
+
+    def read_agents() -> dict[str, Agent]:
         """Read agent information.
 
-        Stored in data/agents
+        Loads built-in agents from data/agents, then custom agents from
+        <toad_config_path>/agents/. Custom agents with the same identity
+        will override built-in ones.
 
         Returns:
-            List of agent dicts.
+            Mapping of identity to agent dicts.
         """
-        agents: list[Agent] = []
+        agents: dict[str, Agent] = {}
+
+        def add_agent(agent: Agent) -> None:
+            identity = agent.get("identity")
+            if identity:
+                agents[identity] = agent
+
         try:
             for file in files("toad.data").joinpath("agents").iterdir():
-                agent: Agent = tomllib.load(file.open("rb"))
-                if agent.get("active", True):
-                    agents.append(agent)
+                if agent := load_agent(file):
+                    add_agent(agent)
 
+            custom_agents_dir = get_config() / "agents"
+            if custom_agents_dir.exists():
+                for file in custom_agents_dir.glob("*.toml"):
+                    if agent := load_agent(file):
+                        add_agent(agent)
         except Exception as error:
             raise AgentReadError(f"Failed to read agents; {error}")
 
         return agents
 
-    agents = await asyncio.to_thread(read_agents)
-    agent_map = {agent["identity"]: agent for agent in agents}
-
-    return agent_map
+    return await asyncio.to_thread(read_agents)

--- a/src/toad/cli.py
+++ b/src/toad/cli.py
@@ -24,7 +24,8 @@ async def get_agent_data(launch_agent) -> Agent | None:
     from toad.agents import read_agents, AgentReadError
 
     try:
-        agents = await read_agents()
+        result = await read_agents()
+        agents = result.agents
     except AgentReadError:
         agents = {}
 

--- a/src/toad/screens/store.py
+++ b/src/toad/screens/store.py
@@ -24,7 +24,7 @@ from toad.pill import pill
 from toad.widgets.mandelbrot import Mandelbrot
 from toad.widgets.grid_select import GridSelect
 from toad.agent_schema import Agent
-from toad.agents import read_agents
+from toad.agents import read_agents, AgentReadResult
 
 
 QR = """\
@@ -419,7 +419,15 @@ class StoreScreen(Screen):
     async def on_mount(self) -> None:
         self.app.settings_changed_signal.subscribe(self, self.setting_updated)
         try:
-            self._agents = await read_agents()
+            result = await read_agents()
+            self._agents = result.agents
+            for error in result.validation_errors:
+                self.notify(
+                    f"[b]{error.file_path.name}[/b]: {error.error_message}",
+                    title="Custom agent validation error",
+                    severity="warning",
+                    timeout=10,
+                )
         except Exception as error:
             self.notify(
                 f"Failed to read agents data ({error})",


### PR DESCRIPTION
**Link to the discussion** - https://github.com/batrachianai/toad/discussions/163

This PR added support for loading custom agents from `<config_home>/agents/*.toml`

e.g. I added

```toml
# Schema defined in agent_schema.py
# https://github.com/jingkaihe/kodelet

identity = "kodelet"
name = "Kodelet"
short_name = "kodelet"
url = "https://github.com/jingkaihe/kodelet"
protocol = "acp"
author_name = "Jingkai He"
author_url = "https://github.com/jingkaihe/kodelet"
publisher_name = "Jingkai He"
publisher_url = "https://github.com/jingkaihe/kodelet"
type = "coding"
description = "Kodelet is a lightweight agentic SWE Agent. It runs as an interactive CLI tool in your terminal. It is capable of peforming software engineering and production operating tasks."
tags = []
run_command."*" = "kodelet acp"

help = '''
...
```

into `~/.config/toad/agents/kodelet.toml`, agents become available from the tui on `toad` launch:

<img width="342" height="186" alt="image" src="https://github.com/user-attachments/assets/a147c47c-55dc-4e8c-82c3-2376af860ae9" />


This allows me to launch custom agent via `toad serve` which otherwise isn't available.