### PR TITLE
fix content crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.28] - 2026-01-11
+
+###
+
+- Fixed crash when running commands that clash with Content markup
+
 ## [0.5.27] - 2026-01-10
 
 ### Changed
@@ -201,6 +207,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - First release. This document will be updated for subsequent releases.
 
+[0.5.28]: https://github.com/batrachianai/toad/compare/v0.5.27...v0.5.28
+[0.5.27]: https://github.com/batrachianai/toad/compare/v0.5.26...v0.5.27
 [0.5.26]: https://github.com/batrachianai/toad/compare/v0.5.25...v0.5.26
 [0.5.24]: https://github.com/batrachianai/toad/compare/v0.5.23...v0.5.24
 [0.5.23]: https://github.com/batrachianai/toad/compare/v0.5.22...v0.5.23

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "batrachian-toad"
-version = "0.5.27"
+version = "0.5.28"
 description = "A unified experience for AI in your terminal."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/src/toad/screens/action_modal.py
+++ b/src/toad/screens/action_modal.py
@@ -4,6 +4,7 @@ from textual.app import ComposeResult
 from textual import on, work
 from textual import containers
 from textual import getters
+from textual.content import Content
 from textual.screen import ModalScreen
 from textual import widgets
 from textual.widget import Widget
@@ -63,7 +64,7 @@ class ActionModal(ModalScreen):
 
     def on_mount(self) -> None:
         self.ok_button.loading = True
-        self.command_pane.border_title = self._title
+        self.command_pane.border_title = Content(self._title)
 
         self.run_command()
 

--- a/src/toad/widgets/command_pane.py
+++ b/src/toad/widgets/command_pane.py
@@ -177,6 +177,7 @@ class CommandPane(Terminal):
 
 if __name__ == "__main__":
     from textual.app import App, ComposeResult
+    from textual.content import Content
 
     COMMAND = os.environ["SHELL"]
     # COMMAND = "python test_input.py"
@@ -217,7 +218,7 @@ if __name__ == "__main__":
 
         def on_mount(self) -> None:
             command_pane = self.query_one(CommandPane)
-            command_pane.border_title = COMMAND
+            command_pane.border_title = Content(COMMAND)
             command_pane.execute(COMMAND)
 
     app = CommandApp()

--- a/src/toad/widgets/shell_terminal.py
+++ b/src/toad/widgets/shell_terminal.py
@@ -1,5 +1,7 @@
 from typing import Iterable
 
+from textual.content import Content
+
 from toad.menus import MenuItem
 from toad.widgets.terminal import Terminal
 
@@ -12,7 +14,7 @@ class ShellTerminal(Terminal):
         yield
 
     def on_mount(self) -> None:
-        self.border_title = self.name
+        self.border_title = Content(self.name)
 
     def get_block_content(self, destination: str) -> str | None:
         return "\n".join(line.content.plain for line in self.state.buffer.lines)

--- a/src/toad/widgets/terminal_tool.py
+++ b/src/toad/widgets/terminal_tool.py
@@ -152,7 +152,7 @@ class TerminalTool(Terminal):
         self._released = True
 
     def watch__command(self, command: Command) -> None:
-        self.border_title = str(command)
+        self.border_title = Content(str(command))
 
     async def start(self, width: int = 0, height: int = 0) -> None:
         assert self._command is not None


### PR DESCRIPTION
Fixes https://github.com/batrachianai/toad/discussions/182

We want to prevent the border title attribute from being parsed as Content markup