### PR TITLE
Fix typo in store screen label

### DIFF
--- a/src/toad/screens/store.py
+++ b/src/toad/screens/store.py
@@ -179,7 +179,7 @@ class Launcher(containers.VerticalGroup):
                     yield LauncherItem(digit or "", agents[identity])
 
         if not launcher_agents:
-            yield widgets.Label("Chose your fighter below!", classes="no-agents")
+            yield widgets.Label("Choose your fighter below!", classes="no-agents")
 
 
 class LauncherItem(containers.VerticalGroup):


### PR DESCRIPTION
Corrected 'Chose your fighter below!' to 'Choose your fighter below!' in the launcher screen when no agents are available.