### PR TITLE
fix: small spelling mistake in copilot cli description

### DIFF
--- a/src/toad/data/agents/copilot.github.com.toml
+++ b/src/toad/data/agents/copilot.github.com.toml
@@ -18,7 +18,7 @@ run_command."*" = "copilot --acp"
 help = '''
 # GitHub Copilot
 
-GitHub Copilot CLI brings AI-powered coding assistanc"e directly to your command line, enabling you to build, debug, and understand code through natural language conversations. Powered by the same agentic harness as GitHub's Copilot coding agent, it provides intelligent assistance while staying deeply integrated with your GitHub workflow.
+GitHub Copilot CLI brings AI-powered coding assistance directly to your command line, enabling you to build, debug, and understand code through natural language conversations. Powered by the same agentic harness as GitHub's Copilot coding agent, it provides intelligent assistance while staying deeply integrated with your GitHub workflow.
 
 Install vial the select below, or see the README for [alternative install methods](https://github.com/github/copilot-cli?tab=readme-ov-file#installation)
 


### PR DESCRIPTION
This made me sad!

<img width="1013" height="129" alt="image" src="https://github.com/user-attachments/assets/64bb1c06-94cc-4e5f-b45c-7bde496a1ca0" />
